### PR TITLE
Added PKGBUILD for Arch users

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Paul Black <paul@blackfamily.one>
+
+pkgname=si-edit-git
+pkgver=0.0.1
+pkgrel=1
+pkgdesc="Tools for working with SI files from LEGO Island."
+arch=('i686' 'x86_64')
+url="https://github.com/itsmattkc/SIEdit"
+license=('GPLv3')
+depends=('qt5-base' 'qt5-tools' 'qt5-multimedia' 'ffmpeg')
+makedepends=('git' 'make' 'cmake')
+source=('git+https://github.com/itsmattkc/SIEdit.git')
+md5sums=('SKIP')
+
+build() {
+        cd "$srcdir/SIEdit"
+        mkdir -p build
+        cd build
+        cmake ..
+        make
+}
+
+package() {
+        cd "$srcdir/SIEdit/build/app"
+        install -Dm755 si-edit "$pkgdir/usr/bin/si-edit"
+}
+


### PR DESCRIPTION
This commit adds a PKGBUILD for those that use Arch Linux. 

The only thing I'm not sure about is handling versioning with SIEdit at its current state. We can go for a "fake" 0.0.1 like I'm doing currently and just keep doing that till real version numbers get added, or if you have a better idea, I'm all ears.

Either way, the PKGBUILD works perfectly, for me at least. Would love if you could test it too. 

Thanks!

After we get that figured out, I'm happy to add it to the AUR.